### PR TITLE
Removed lateral margin in Event pages

### DIFF
--- a/components/Events/EventSingle.vue
+++ b/components/Events/EventSingle.vue
@@ -5,7 +5,7 @@
         <h4 class="text-josa-blue mb-2">{{ event.startDate | dayDate($i18n.locale) }}</h4>
         <h2>{{ event['title_' + $i18n.locale] }}</h2>
         <div class="content flex flex-wrap md:flex-no-wrap mt-12">
-          <div class="w-full md:w-3/5 ltr:mr-8 rtl:ml-8 mb-8">
+          <div class="w-full md:w-3/5 md:ltr:mr-8 md:rtl:ml-8 mb-8">
             <appImage v-if="event.thumbnail" :image="event.thumbnail" size="large" class="thumbnail" />
             <img v-else class="thumbnail md:ltr:mr-6 md:rtl:ml-6 w-full" :src="placeholderImage" />
             <shareButtons v-if="url" :url="url" class="mt-8 w-full justify-end" />


### PR DESCRIPTION
- Fixes #369. 

- Files changed: 
components/Events/EventSingle.vue

- Changes made: 
I have set the 2 rem margin to be conditionally applied only on medium screens and larger.  I did this by prefixing the margin utility with the breakpoint name 'md'. Thus, it will do nothing on smaller screens (i.e. margin will be automatically mr-0 for ltr and ml-0 for rtl). 