### PR TITLE
Issue 403

### DIFF
--- a/components/Contact/AddressCard.vue
+++ b/components/Contact/AddressCard.vue
@@ -8,7 +8,7 @@
           <div class="ltr:pl-8 rtl:pr-8">
             <p>{{ info.address['addressOne_' + $i18n.locale] }}</p>
             <p>{{ info.address['addressTwo_' + $i18n.locale] }}</p>
-            <p class="mt-4">{{ info.address['street_' + $i18n.locale] }}, {{ info.address['city_' + $i18n.locale] }}</p>
+            <p class="mt-4">{{ info.address['street_' + $i18n.locale] }}{{ $t('contact.comma') }} {{ info.address['city_' + $i18n.locale] }}</p>
           </div>
         </div>
         <div class="mb-6 w-full">

--- a/lang/ar.js
+++ b/lang/ar.js
@@ -54,7 +54,8 @@ export default {
     workingHours: 'ساعات العمل',
     voice: 'هاتف',
     email: 'البريد الإلكتروني',
-    connect: 'تواصل معنا'
+    connect: 'تواصل معنا',
+    comma: '،'
   },
   // Feedback
   feedback: {

--- a/lang/en.js
+++ b/lang/en.js
@@ -194,7 +194,8 @@ export default {
     workingHours: 'Working Hours',
     voice: 'Voice',
     email: 'Email',
-    connect: 'Connect with us'
+    connect: 'Connect with us',
+    comma: ',',
   },
   feedback: {
     title: 'Feedback and Inquiries',


### PR DESCRIPTION
## Issue Solving
Issue #403 - incorrect comma in address

## Changes Made
The addressCard component had a hard-code `,` in the address. This is correct in English translation of website but not in other languages.

In the international translation files in the `contact` object added a key for `comma`. This will have the English version in the English translation and the correct comma in other languages.

Updated the AddressCard component to replace the hard-coded comma with the appropriate language translation version of the comma.