### PR TITLE
Removed the upcoming events section 

### DIFF
--- a/components/Programs/ProgramSingle.vue
+++ b/components/Programs/ProgramSingle.vue
@@ -25,8 +25,6 @@
         <trivia v-if="program.trivia[0]" :info="program.trivia[0]" />
         <trivia v-if="program.trivia[1]" :info="program.trivia[1]" alt />
       </div>
-      <!-- Upcoming Events -->
-      <upcomingEvents :title="$t('events.upcoming')" category="all" :numberOfEvents="2" />
     </div>
   </div>
 </template>
@@ -34,7 +32,6 @@
 <script>
   import pageBanner from "~/components/UI/PageBannerNoImage";
   import trivia from '~/components/UI/Trivia';
-  import upcomingEvents from '~/components/Events/UpcomingEvents';
   import latestArticles from "~/components/Blog/LatestArticlesNoFetch";
   import activitiesList from '@/components/Activities/ActivitiesList';
   import Vue2Filters from 'vue2-filters';
@@ -44,7 +41,6 @@
     components: {
       pageBanner,
       trivia,
-      upcomingEvents,
       latestArticles,
       activitiesList
     },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -25,12 +25,6 @@
         </div>
       </div>
     </div>
-    <!-- Upcoming Events -->
-    <div class="container">
-      <div class="row pb-20">
-        <upcomingEvents :title="$t('events.upcoming')" category="all" :numberOfEvents="2" />
-      </div>
-    </div>
   </div>
 </template>
 
@@ -38,7 +32,6 @@
   import axios from 'axios';
   import articlesSpotlight from "~/components/Blog/ArticlesSpotlight";
   import lastestPublications from '~/components/Publications/LastestPublications';
-  import upcomingEvents from '~/components/Events/UpcomingEvents';
   import ourWork from '~/components/Programs/OurWork';
   import homeBanner from "~/components/UI/HomeBanner";
   import joinUs from "~/components/JoinUs/JoinUs";
@@ -51,7 +44,6 @@
       homeBanner,
       articlesSpotlight,
       lastestPublications,
-      upcomingEvents,
       joinUs
     },
     head() {


### PR DESCRIPTION
## Issue Addressed
Addresses Issue #385  - Remove the `Upcoming Events` section from the homepage and the Program pages

## Changes Made
Removed the UpcomingEvents component from the homepage. 
Removed the Upcoming Events component from the ProgramSingle page. This page covers both Open Source Hardware and Open Source Software