### PR TITLE
Add browser history on blogList page change

### DIFF
--- a/components/Blog/BlogList.vue
+++ b/components/Blog/BlogList.vue
@@ -83,6 +83,20 @@
         return this.$store.getters.getFeaturedBlogs
       }
     },
+    watch: {
+      /**
+       * On currentPage change, add ?page=x in URL to add browser history on page change
+       */
+      currentPage(currentPage) {
+        this.$router.push({
+          path: this.$route.path,
+          query: {
+            ...this.$route.query,
+            page: currentPage
+          }
+        })
+      },
+    },
     created() {
       this.fetchArticles()
       this.countArticles()


### PR DESCRIPTION
This PR _maybe_ fixes #409 

I was not able to build the project locally due to some issues with fetching menu.
However, I think this PR should fix the problem regarding blog list not "remembering" the last page you were on when you change the browser history (go back in the browser).

The idea of the fix is to add a query param to the URL once `currentPage` variable changes. I think this will make the browser add the different pages to the browser history.

Please test the PR in your setup and give me some feedback if it works or not. 👍 