### PR TITLE
Remove extra space from blog posts and events' pages

### DIFF
--- a/components/ShareButtons/ShareButtons.vue
+++ b/components/ShareButtons/ShareButtons.vue
@@ -11,7 +11,7 @@
         </a>
         <span class="share-button tooltip" @click="copyToClipboard(url)">
             <font-awesome-icon icon="link" :size="faSize" />
-            <span ref="copyButton" class="copy-tooltip-text invisible"></span>
+            <span ref="copyButton" class="copy-tooltip-text kopieren invisible"></span>
         </span>
     </div>
 </template>
@@ -62,5 +62,9 @@
 
     [dir="rtl"] .share-button {
         @apply mr-4 ml-0;
+    }
+    [dir="ltr"] .kopieren {
+      right: 0;
+      bottom: -37px;
     }
 </style>


### PR DESCRIPTION
Fixes #432 

Changes made: 
I have changed the position of the **'copy to clipboard' tooltip** in `ShareButtons.vue`.