### PR TITLE
Remove extra space from the single event and single blog page

### DIFF
--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -306,7 +306,6 @@ ul {
 }
 
 [dir='ltr'] .copy-tooltip-text {
-  right: -75px;
   right: 0px;
   left: unset;
   bottom: -37px;

--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -312,8 +312,9 @@ ul {
 }
 
 [dir='rtl'] .copy-tooltip-text {
-  left: -75px;
-  right: unset;
+  right: -37px;
+  left: unset;
+  bottom: -37px;
 }
 
 /*****/

--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -307,7 +307,9 @@ ul {
 
 [dir='ltr'] .copy-tooltip-text {
   right: -75px;
+  right: 0px;
   left: unset;
+  bottom: -37px;
 }
 
 [dir='rtl'] .copy-tooltip-text {


### PR DESCRIPTION
Fixes #118 

### Changes made:
I have changed the placement of the 'copy to clipboard' tooltip (for both RTL and LTR). 