### PR TITLE
Fix metadata not showing the description of the event when the link is shared

### DIFF
--- a/pages/events/_id/_slug.vue
+++ b/pages/events/_id/_slug.vue
@@ -30,8 +30,8 @@ export default {
       meta: [
         {
           name: 'description',
-          content: this.event['metaDescription_' + this.$i18n.locale]
-            ? this.event['metaDescription_' + this.$i18n.locale]
+          content: this.event['description_' + this.$i18n.locale]
+            ? this.event['description_' + this.$i18n.locale]
             : '',
         },
         ...this.$options.filters.ogTags(


### PR DESCRIPTION
This fixes Issue #129 