### PR TITLE
Fix error when the event is not online

### DIFF
--- a/components/Events/EventSingle.vue
+++ b/components/Events/EventSingle.vue
@@ -106,7 +106,7 @@ export default {
     }
   },
   async fetch() {
-    if (this.event.onlineMeeting.meetingID) {
+    if (this.event.onlineMeeting) {
       const url = this.$config.bbbAPIUrl
       const secret = this.$config.bbbAPISecret
       const meetingID = this.event.onlineMeeting.meetingID


### PR DESCRIPTION
This get rids of the error that appears when the page tries to connect to the big blue button service when the meeting is offline