### PR TITLE
Fix the vertical alignment of icons in the Careers Page

### DIFF
--- a/components/Careers/InfoCard.vue
+++ b/components/Careers/InfoCard.vue
@@ -34,7 +34,7 @@
       <div class="ltr:ml-3 rtl:mr-3">
         <h5 class="leading-none mb-1">{{ $t('careers.type') }}</h5>
         <p>
-          {{ career.careerType['title_' + $i18n.locale] }}/
+          {{ career.careerType['title_' + $i18n.locale] }}
           {{ career['period_' + $i18n.locale] }}
         </p>
       </div>

--- a/components/Careers/InfoCard.vue
+++ b/components/Careers/InfoCard.vue
@@ -1,31 +1,37 @@
 <template>
   <div class="p-4 bg-josa-warm-grey-light">
     <div class="info-card">
-      <font-awesome-icon
-        class="icon ltr:mr-3 rtl:ml-3"
-        :icon="['fas', 'clock']"
-      />
-      <div>
+      <div class="w-8">
+        <font-awesome-icon
+          class="fa-fw icon ltr:mr-3 rtl:ml-3"
+          :icon="['fas', 'calendar-day']"
+        />
+      </div>
+      <div class="ltr:ml-3 rtl:mr-3">
         <h5 class="leading-none mb-1">{{ $t('careers.publishDate') }}</h5>
         <p>{{ career.publishDate | dayFullDate($i18n.locale) }}</p>
       </div>
     </div>
     <div class="info-card">
-      <font-awesome-icon
-        class="icon ltr:mr-3 rtl:ml-3"
-        :icon="['fas', 'map-marker-alt']"
-      />
-      <div>
+      <div class="w-8">
+        <font-awesome-icon
+          class="fa-fw icon ltr:mr-3 rtl:ml-3"
+          :icon="['fas', 'globe-europe']"
+        />
+      </div>
+      <div class="ltr:ml-3 rtl:mr-3">
         <h5 class="leading-none mb-1">{{ $t('locationCard.title') }}</h5>
         <p>{{ career['location_' + $i18n.locale] }}</p>
       </div>
     </div>
     <div class="info-card">
-      <font-awesome-icon
-        class="icon ltr:mr-3 rtl:ml-3"
-        :icon="['fas', 'clipboard-list']"
-      />
-      <div>
+      <div class="w-8">
+        <font-awesome-icon
+          class="fa-fw icon ltr:mr-3 rtl:ml-3"
+          :icon="['fas', 'file-signature']"
+        />
+      </div>
+      <div class="ltr:ml-3 rtl:mr-3">
         <h5 class="leading-none mb-1">{{ $t('careers.type') }}</h5>
         <p>
           {{ career.careerType['title_' + $i18n.locale] }}/
@@ -34,11 +40,13 @@
       </div>
     </div>
     <div class="info-card">
-      <font-awesome-icon
-        class="icon ltr:mr-3 rtl:ml-3"
-        :icon="['fas', 'user']"
-      />
-      <div>
+      <div class="w-8">
+        <font-awesome-icon
+          class="fa-fw icon ltr:mr-3 rtl:ml-3"
+          :icon="['fas', 'user-friends']"
+        />
+      </div>
+      <div class="ltr:ml-3 rtl:mr-3">
         <h5 class="leading-none mb-1">{{ $t('careers.team') }}</h5>
         <p>{{ career.team['title_' + $i18n.locale] }}</p>
       </div>


### PR DESCRIPTION
Fixes #121. 

- Changing the styling of icons was not enough since they don't have equal width, so I had to change the icons. Moreover, the icons used were sort of irrelevant. 
- I have also removed an extra ` / ` from the info card. 