### PR TITLE
patch: publication download card link

### DIFF
--- a/components/Publications/DownloadCard.vue
+++ b/components/Publications/DownloadCard.vue
@@ -22,7 +22,7 @@ export default {
   },
   computed: {
     fileUrl() {
-      return this.fileLink
+      return /^https/.test(this.fileLink) ? this.fileLink : `https://${this.fileLink}`
     },
   },
 }


### PR DESCRIPTION
add url format check

fixes the isseu with digital ocean links that dont start with https